### PR TITLE
chore: bump to 3.3.4

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Roland Kiraly <rolandgyulakiraly at outlook dot com>
 # https://github.com/raverecursion/nordlayer-latest/tree/master
 pkgname=nordlayer
-pkgver=3.3.1
+pkgver=3.3.4
 pkgrel=1
 pkgdesc="Proprietary VPN client for Linux"
 arch=('x86_64')
@@ -13,7 +13,7 @@ depends=('bash' 'libgcrypt' 'libgpg-error' 'libcap' 'hicolor-icon-theme' 'gmp' '
 options=('!strip' '!emptydirs')
 install=${pkgname}.install
 source_x86_64=("https://downloads.nordlayer.com/linux/latest/debian/pool/main/nordlayer_${pkgver}_amd64.deb")
-sha512sums_x86_64=('56054790a31894177b48837e9fb4dc95178b7f243f87a3a4bbab92729fc16387316df7cb1c21c58d852d2497eb75e9d124e09da0f116cf2b06841231b3823b14')
+sha512sums_x86_64=('816ac766f4c98fc10052bbd20bff643fc0a48be4b2fc56ab5a3cdb26934f1b38a1022e5d747537486f0be4d1b7aeafd3f1ed5ff33d3f8589394abce57dc8fed1')
 
 package() {
     cd "${srcdir}"


### PR DESCRIPTION
Unsure what's the procedure for the PR here but installed it locally via readme commands and all is good.
The readme was already out of date, I didn't want to add changes that would be un-expected